### PR TITLE
允许出现长度为0的List

### DIFF
--- a/core/src/main/java/cc/carm/lib/configuration/core/value/type/ConfiguredList.java
+++ b/core/src/main/java/cc/carm/lib/configuration/core/value/type/ConfiguredList.java
@@ -38,8 +38,9 @@ public class ConfiguredList<V> extends CachedConfigValue<List<V>> {
     public @NotNull List<V> get() {
         if (isExpired()) { // 已过时的数据，需要重新解析一次。
             List<V> list = new ArrayList<>();
-            List<?> data = getConfiguration().getList(getConfigPath());
-            if (data == null || data.isEmpty()) return useOrDefault(list);
+            List<?> data = getConfiguration().contains(getConfigPath()) ?
+                    getConfiguration().getList(getConfigPath()) : null;
+            if (data == null) return useOrDefault(list);
             for (Object dataVal : data) {
                 if (dataVal == null) continue;
                 try {


### PR DESCRIPTION
```java
public static final ConfiguredList<String> TESTLIST = ConfiguredList.builder(String.class).fromString()
            .defaults("123").build();
```
```yaml
testlist:
  - 123
  - 234
```
以上内容解析后会是这样一个列表`[123, 234]`

可如果我把YML文件改为下面这样
```yaml
testlist: []
```
我的意图是保留一个**没有数据的列表**，可是解析时会判断列表是否为空（即**长度为0**），认为该值不存在，最后结果还是默认值`[123]`

我希望的是可以**允许长度为0的列表存在**而不是一定有至少一个数值否则就会调用默认值