### PR TITLE
完成对 HOCON 格式的支持

### DIFF
--- a/impl/hocon/pom.xml
+++ b/impl/hocon/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>cc.carm.lib</groupId>
+        <artifactId>easyconfiguration-parent</artifactId>
+        <version>3.6.0</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>easyconfiguration-hocon</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>${project.jdk.version}</maven.compiler.source>
+        <maven.compiler.target>${project.jdk.version}</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.encoding>UTF-8</maven.compiler.encoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>easyconfiguration-core</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>easyconfiguration-demo</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.typesafe</groupId>
+            <artifactId>config</artifactId>
+            <version>1.4.2</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/EasyConfiguration.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/EasyConfiguration.java
@@ -1,0 +1,31 @@
+package cc.carm.lib.configuration;
+
+import cc.carm.lib.configuration.hocon.HOCONFileConfigProvider;
+
+import java.io.File;
+import java.io.IOException;
+
+public class EasyConfiguration {
+    public static HOCONFileConfigProvider from(File file, String source) {
+        HOCONFileConfigProvider provider = new HOCONFileConfigProvider(file);
+        try {
+            provider.initializeFile(source);
+            provider.initializeConfig();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return provider;
+    }
+
+    public static HOCONFileConfigProvider from(File file) {
+        return from(file, file.getName());
+    }
+
+    public static HOCONFileConfigProvider from(String fileName) {
+        return from(fileName, fileName);
+    }
+
+    public static HOCONFileConfigProvider from(String fileName, String source) {
+        return from(new File(fileName), source);
+    }
+}

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/CommentedHOCON.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/CommentedHOCON.java
@@ -1,0 +1,26 @@
+package cc.carm.lib.configuration.hocon;
+
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.Set;
+
+public interface CommentedHOCON {
+    default @NotNull Set<String> getKeys() {
+        return getKeys(null, true);
+    }
+
+    String serializeValue(@NotNull String key, @NotNull Object value);
+
+    @Contract("null,_ -> !null;!null,_ -> _")
+    @Nullable Set<String> getKeys(@Nullable String sectionKey, boolean deep);
+
+    @Nullable Object getValue(@NotNull String key);
+
+    @Nullable String getInlineComment(@NotNull String key);
+
+    @Nullable
+    List<String> getHeaderComments(@Nullable String key);
+}

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/HOCONConfigWrapper.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/HOCONConfigWrapper.java
@@ -1,0 +1,117 @@
+package cc.carm.lib.configuration.hocon;
+
+import cc.carm.lib.configuration.core.source.ConfigurationWrapper;
+import cc.carm.lib.configuration.hocon.util.HOCONUtils;
+import com.typesafe.config.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.*;
+
+public class HOCONConfigWrapper implements ConfigurationWrapper<Map<String, Object>> {
+    private static final char SEPARATOR = '.';
+    protected final Map<String, Object> data;
+
+    public HOCONConfigWrapper(ConfigObject config) {
+        this.data = new LinkedHashMap<>();
+
+        config.forEach((key, value) -> {
+            Config cfg = config.toConfig();
+            ConfigValue cv = cfg.getValue(key);
+            if (cv.valueType() == ConfigValueType.OBJECT) {
+                HOCONConfigWrapper.this.data.put(key, new HOCONConfigWrapper((ConfigObject) cv));
+            } else {
+                HOCONConfigWrapper.this.data.put(key, value.unwrapped());
+            }
+        });
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getSource() {
+        return this.data;
+    }
+
+    @Override
+    public @NotNull Set<String> getKeys(boolean deep) {
+        return this.getValues(deep).keySet();
+    }
+
+    @Override
+    public @NotNull Map<String, Object> getValues(boolean deep) {
+        return HOCONUtils.getKeysFromObject(this, deep, "").stream().collect(
+                LinkedHashMap::new,
+                (map, key) -> map.put(key, get(key)),
+                LinkedHashMap::putAll
+        );
+    }
+
+    @Override
+    public void set(@NotNull String path, @Nullable Object value) {
+        if (value instanceof Map) {
+            //noinspection unchecked
+            value = new HOCONConfigWrapper(ConfigFactory.parseMap((Map<String, ?>) value).root());
+        }
+
+        HOCONConfigWrapper section = HOCONUtils.getObjectOn(this, path, SEPARATOR);
+        String simplePath = HOCONUtils.getSimplePath(path, SEPARATOR);
+
+        if (value == null) {
+            section.data.remove(simplePath);
+        } else {
+            section.setDirect(simplePath, value);
+        }
+    }
+
+    /**
+     * 只能设置当前路径下的内容
+     * 避免环回
+     *
+     * @param path 路径
+     */
+    public void setDirect(@NotNull String path, @Nullable Object value) {
+        this.data.put(path, value);
+    }
+
+    @Override
+    public boolean contains(@NotNull String path) {
+        return this.get(path) != null;
+    }
+
+    @Override
+    public @Nullable Object get(@NotNull String path) {
+        HOCONConfigWrapper section = HOCONUtils.getObjectOn(this, path, SEPARATOR);
+        return section.getDirect(HOCONUtils.getSimplePath(path, SEPARATOR));
+    }
+
+    /**
+     * 只能获取当前路径下的内容
+     * 避免环回
+     *
+     * @param path 路径
+     */
+    public Object getDirect(@NotNull String path) {
+        return this.data.get(path);
+    }
+
+    @Override
+    public boolean isList(@NotNull String path) {
+        return this.get(path) instanceof List<?>;
+    }
+
+    @Override
+    public @Nullable List<?> getList(@NotNull String path) {
+        Object val = this.get(path);
+        return (val instanceof List<?>) ? (List<?>) val : null;
+    }
+
+    @Override
+    public boolean isConfigurationSection(@NotNull String path) {
+        return this.get(path) instanceof HOCONConfigWrapper;
+    }
+
+    @Override
+    public @Nullable ConfigurationWrapper<Map<String, Object>> getConfigurationSection(@NotNull String path) {
+        Object val = get(path);
+        return (val instanceof HOCONConfigWrapper) ? (HOCONConfigWrapper) val : null;
+    }
+}

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/HOCONFileConfigProvider.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/HOCONFileConfigProvider.java
@@ -1,0 +1,103 @@
+package cc.carm.lib.configuration.hocon;
+
+import cc.carm.lib.configuration.core.ConfigInitializer;
+import cc.carm.lib.configuration.core.source.ConfigurationComments;
+import cc.carm.lib.configuration.core.source.impl.FileConfigProvider;
+import cc.carm.lib.configuration.hocon.exception.HOCONGetValueException;
+import cc.carm.lib.configuration.hocon.util.HOCONUtils;
+import com.typesafe.config.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Set;
+
+public class HOCONFileConfigProvider extends FileConfigProvider<HOCONConfigWrapper> implements CommentedHOCON {
+    protected final @NotNull ConfigurationComments comments = new ConfigurationComments();
+    protected HOCONConfigWrapper configuration;
+    protected ConfigInitializer<HOCONFileConfigProvider> initializer;
+
+    public HOCONFileConfigProvider(@NotNull File file) {
+        super(file);
+        this.initializer = new ConfigInitializer<>(this);
+    }
+
+    public void initializeConfig() {
+        try {
+            this.configuration = new HOCONConfigWrapper(ConfigFactory.parseFile(this.file, ConfigParseOptions.defaults()
+                    .setSyntax(ConfigSyntax.CONF)
+                    .setAllowMissing(false)).root());
+        } catch (ConfigException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public @NotNull HOCONConfigWrapper getConfiguration() {
+        return this.configuration;
+    }
+
+    @Override
+    public void save() throws IOException {
+        Files.write(this.file.toPath(), HOCONUtils.renderWithComment(configuration, comments::getHeaderComment).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    protected void onReload() throws ConfigException {
+        this.configuration = new HOCONConfigWrapper(ConfigFactory.parseFile(this.file, ConfigParseOptions.defaults()
+                .setSyntax(ConfigSyntax.CONF)
+                .setAllowMissing(false)).root());
+    }
+
+    @Override
+    public @NotNull ConfigurationComments getComments() {
+        return this.comments;
+    }
+
+    @Override
+    public @NotNull ConfigInitializer<HOCONFileConfigProvider> getInitializer() {
+        return this.initializer;
+    }
+
+    @Override
+    public String serializeValue(@NotNull String key, @NotNull Object value) {
+        // 带有 key=value 的新空对象
+        return ConfigFactory.empty()
+                .withValue(key, ConfigValueFactory.fromAnyRef(value))
+                .root().render();
+    }
+
+    @Override
+    public @Nullable Set<String> getKeys(@Nullable String sectionKey, boolean deep) {
+        if (sectionKey == null) { // 当前路径
+            return HOCONUtils.getKeysFromObject(this.configuration, deep, "");
+        }
+
+        HOCONConfigWrapper section;
+        try {
+            // 获取目标字段所在路径
+            section = (HOCONConfigWrapper) this.configuration.get(sectionKey);
+        } catch (ClassCastException e) {
+            // 值和类型不匹配
+            throw new HOCONGetValueException(e);
+        }
+        if (section == null) {
+            return null;
+        }
+        return HOCONUtils.getKeysFromObject(section, deep, "");
+    }
+
+    @Override
+    public @Nullable Object getValue(@NotNull String key) {
+        return this.configuration.get(key);
+    }
+
+    @Override
+    public @Nullable List<String> getHeaderComments(@Nullable String key) {
+        return this.comments.getHeaderComment(key);
+    }
+}

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/exception/HOCONGetValueException.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/exception/HOCONGetValueException.java
@@ -1,0 +1,19 @@
+package cc.carm.lib.configuration.hocon.exception;
+
+public class HOCONGetValueException extends RuntimeException {
+    public HOCONGetValueException() {
+        super();
+    }
+
+    public HOCONGetValueException(String message) {
+        super(message);
+    }
+
+    public HOCONGetValueException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public HOCONGetValueException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/source/StringConfigProvider.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/source/StringConfigProvider.java
@@ -1,0 +1,23 @@
+package cc.carm.lib.configuration.hocon.source;
+
+import cc.carm.lib.configuration.core.source.ConfigurationProvider;
+import cc.carm.lib.configuration.core.source.ConfigurationWrapper;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * 暂时未实现，原因是如果要实现，就需要修改部分代码
+ * @see ConfigurationProvider#save()
+ * @see ConfigurationProvider#reload()
+ * 等一系列代码
+ */
+public abstract class StringConfigProvider<W extends ConfigurationWrapper<?>> extends ConfigurationProvider<W> {
+    protected final @NotNull String source;
+
+    protected StringConfigProvider(@NotNull String source) {
+        this.source = source;
+    }
+
+    public @NotNull String getSource() {
+        return this.source;
+    }
+}

--- a/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/util/HOCONUtils.java
+++ b/impl/hocon/src/main/java/cc/carm/lib/configuration/hocon/util/HOCONUtils.java
@@ -1,0 +1,105 @@
+package cc.carm.lib.configuration.hocon.util;
+
+import cc.carm.lib.configuration.hocon.HOCONConfigWrapper;
+import cc.carm.lib.configuration.hocon.exception.HOCONGetValueException;
+import com.typesafe.config.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public abstract class HOCONUtils {
+    public static String getSimplePath(String path, char separator) {
+        int index = path.lastIndexOf(separator);
+        return (index == -1) ? path : path.substring(index + 1);
+    }
+
+    public static HOCONConfigWrapper getObjectOn(@NotNull HOCONConfigWrapper parent, @NotNull String path, char separator) {
+        String currentPath = path;
+        HOCONConfigWrapper currentObject = parent;
+        int index;
+        while ((index = currentPath.indexOf(separator)) != -1) {
+            HOCONConfigWrapper previousObject = currentObject;
+            String pathName = currentPath.substring(0, index);
+            try {
+                currentObject = (HOCONConfigWrapper) previousObject.getDirect(pathName);
+            } catch (ClassCastException e) {
+                throw new HOCONGetValueException(e);
+            }
+            if (currentObject == null) {
+                currentObject = new HOCONConfigWrapper(ConfigFactory.empty().root());
+                previousObject.setDirect(pathName, currentObject);
+            }
+            currentPath = currentPath.substring(0, index);
+        }
+
+        return currentObject;
+    }
+
+    /**
+     * 在 Object 中获取所有键
+     * 思路：在第一次执行时 prefix 应该是 ""
+     * 后续找到了更深层的键，将会变为 "deep."
+     * 下一次键名就是 "deep.key"
+     *
+     * @param parent Object
+     * @param deep 是否更深层获取
+     * @param prefix 当前 Object 键名前缀
+     * @return Object 中的所有键
+     */
+    public static LinkedHashSet<String> getKeysFromObject(HOCONConfigWrapper parent, boolean deep, String prefix) {
+        return parent.getSource().entrySet().stream().collect(
+                LinkedHashSet::new,
+                (set, entry) -> {
+                    Object value = entry.getValue();
+                    if (value instanceof HOCONConfigWrapper && deep) {
+                        set.addAll(HOCONUtils.getKeysFromObject((HOCONConfigWrapper) value, true, prefix + entry.getKey() + "."));
+                    } else {
+                        set.add(prefix + entry.getKey());
+                    }
+                },
+                LinkedHashSet::addAll
+        );
+    }
+
+    /**
+     * 将 Object 保存为字符串
+     * 并使用注释器打上注释
+     *
+     * @param object Object
+     * @param commenter 注释器
+     * @return 保存的字符串
+     */
+    public static @NotNull String renderWithComment(@NotNull HOCONConfigWrapper object, @NotNull Function<String, List<String>> commenter) {
+        return HOCONUtils.makeConfigWithComment(object, "", commenter).root().render(
+                ConfigRenderOptions.defaults()
+                        .setJson(false)
+                        .setOriginComments(false)
+        );
+    }
+
+    public static @NotNull Config makeConfigWithComment(@NotNull HOCONConfigWrapper object, @NotNull String prefix, @NotNull Function<String, List<String>> commenter) {
+        Config config = ConfigFactory.empty();
+        for (Map.Entry<String, Object> entry : object.getSource().entrySet()) {
+            String key = entry.getKey();
+            String fullKey = prefix + key;
+            Object value = entry.getValue();
+            ConfigValue result;
+            if (value instanceof Iterable) {
+                result = ConfigValueFactory.fromIterable((Iterable<?>) value);
+            } else if (value instanceof HOCONConfigWrapper) {
+                result = makeConfigWithComment((HOCONConfigWrapper) value, fullKey + ".", commenter).root();
+            } else {
+                result = ConfigValueFactory.fromAnyRef(value);
+            }
+            result = result.withOrigin(
+                    ConfigOriginFactory.newSimple()
+                            .withComments(commenter.apply(fullKey))
+            );
+            config = config.withValue(key, result);
+        }
+        return config;
+    }
+}

--- a/impl/hocon/src/test/java/online/flowerinsnow/test/easyconfiguration/HOCONTest.java
+++ b/impl/hocon/src/test/java/online/flowerinsnow/test/easyconfiguration/HOCONTest.java
@@ -1,0 +1,23 @@
+package online.flowerinsnow.test.easyconfiguration;
+
+import cc.carm.lib.configuration.EasyConfiguration;
+import cc.carm.lib.configuration.hocon.HOCONFileConfigProvider;
+import online.flowerinsnow.test.easyconfiguration.config.Config;
+import org.junit.Test;
+
+import java.io.File;
+
+public class HOCONTest {
+    @Test
+    public void onTest() {
+        HOCONFileConfigProvider provider = EasyConfiguration.from(new File("target/hocon.conf"));
+        provider.initialize(Config.class);
+        try {
+            provider.reload();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("Config.TestObject.TEST_BOOLEAN.getNotNull() = " + Config.TestObject.TEST_BOOLEAN.getNotNull());
+    }
+}

--- a/impl/hocon/src/test/java/online/flowerinsnow/test/easyconfiguration/config/Config.java
+++ b/impl/hocon/src/test/java/online/flowerinsnow/test/easyconfiguration/config/Config.java
@@ -1,0 +1,20 @@
+package online.flowerinsnow.test.easyconfiguration.config;
+
+import cc.carm.lib.configuration.core.ConfigurationRoot;
+import cc.carm.lib.configuration.core.annotation.HeaderComment;
+import cc.carm.lib.configuration.core.value.type.ConfiguredList;
+import cc.carm.lib.configuration.core.value.type.ConfiguredValue;
+
+public class Config extends ConfigurationRoot {
+    @HeaderComment("测试字段 int")
+    public static final ConfiguredValue<Integer> TEST_INT = ConfiguredValue.of(Integer.class, 15);
+
+    @HeaderComment("测试字段 List<String>")
+    public static final ConfiguredList<String> TEST_LIST_STRING = ConfiguredList.of(String.class, "li", "li", "li1");
+
+    @HeaderComment("测试对象")
+    public static class TestObject extends ConfigurationRoot {
+        @HeaderComment("测试字段 Boolean")
+        public static final ConfiguredValue<Boolean> TEST_BOOLEAN = ConfiguredValue.of(Boolean.class, true);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>impl/yaml</module>
         <module>impl/json</module>
         <module>impl/sql</module>
+        <module>impl/hocon</module>
     </modules>
 
     <name>EasyConfiguration</name>


### PR DESCRIPTION
新加了一种格式 HOCON 配置文件

> HOCON（Human-Optimized Config Object Notation）是一种配置文件格式，它旨在提供一个人类友好的、易于阅读和编辑的配置语法。HOCON是对JSON（JavaScript Object Notation）格式的扩展，它添加了一些额外的功能和语法元素，使其更适合于配置文件的编写。
>
> HOCON的语法非常灵活，允许在配置文件中使用注释、多行字符串、变量引用和继承等特性。它的主要特点包括：
>
> 1. 对象表示：HOCON使用花括号（`{}`）来表示一个对象，类似于JSON。对象中的键值对使用冒号（`:`）分隔。
> 2. 数组表示：HOCON使用方括号（`[]`）来表示一个数组，类似于JSON。数组中的元素可以是任意类型的值，包括字符串、数字、布尔值、对象或其他数组。
> 3. 字符串表示：HOCON支持单引号（`'`）和双引号（`"`）包围的字符串。它还支持多行字符串，可以使用三个双引号或三个单引号来表示。
> 4. 注释：HOCON允许使用`#`符号来添加注释。注释可以位于行的任何位置，可以是单行注释或多行注释。
> 5. 变量引用：HOCON支持使用`${}`语法来引用其他配置项的值。这使得配置文件中的值可以在不同部分之间进行共享和重用。
> 6. 继承：HOCON允许通过使用`include`关键字将一个配置文件包含到另一个配置文件中，从而实现配置的继承和组合。
> 
> HOCON格式广泛用于各种应用程序和框架中的配置文件，例如Typesafe Config（用于Java和Scala）、Akka（用于构建分布式应用程序）、Play Framework等。它提供了更灵活和可读性更强的配置选项，使得配置文件的编写和维护更加方便。

以上内容来自 ChatGPT

我好像不太喜欢 JSON YAML 之类作为配置文件，我更喜欢 XML 之类的，~~但是你这里一个都没有~~，干脆自己写了一份

<hr />

使用了 [Config](https://github.com/lightbend/config) 作为解析工具 ([Apache-2.0](https://github.com/lightbend/config/blob/main/LICENSE-2.0.txt))

<hr />

有以下限制

1. 本来我是想 添加一种读取方式（使用字符串而非文件），但可惜无法向下兼容
2. 这个解析工具好像不支持 Inline 注释

<hr />

经过测试可以正常使用

写的有点烂，但是，但是

我本来想留着自己用的，都不打算提交 PR 的，爱合不合(

最后感谢卡姆提供这么好用的接口！